### PR TITLE
ForceNew on ExpressRoute SKU change across the availability-zone boundary (fixes erGwScaleToStandard)

### DIFF
--- a/internal/services/network/virtual_network_gateway_resource.go
+++ b/internal/services/network/virtual_network_gateway_resource.go
@@ -732,7 +732,33 @@ func resourceVirtualNetworkGatewayCustomizeDiff(ctx context.Context, d *pluginsd
 		}
 	}
 
+	// The Azure API can't convert an ExpressRoute gateway between the
+	// availability-zone SKUs (ErGw1AZ/ErGw2AZ/ErGw3AZ/ErGwScale) and the
+	// non-availability-zone SKUs (Standard/HighPerformance/UltraPerformance) in
+	// place; the gateway must be deleted and recreated. An in-place change fails
+	// with `ExpressRouteVirtualNetworkGatewayAutoscaleBoundsNotValid`.
+	if d.Id() != "" && gatewayType == string(virtualnetworkgateways.VirtualNetworkGatewayTypeExpressRoute) && d.HasChange("sku") {
+		oldSku, newSku := d.GetChange("sku")
+		if expressRouteGatewaySkuIsAvailabilityZone(oldSku.(string)) != expressRouteGatewaySkuIsAvailabilityZone(newSku.(string)) {
+			if err := d.ForceNew("sku"); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
+}
+
+func expressRouteGatewaySkuIsAvailabilityZone(sku string) bool {
+	switch virtualnetworkgateways.VirtualNetworkGatewaySkuName(sku) {
+	case virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwOneAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwTwoAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwThreeAZ,
+		virtualnetworkgateways.VirtualNetworkGatewaySkuNameErGwScale:
+		return true
+	default:
+		return false
+	}
 }
 
 func resourceVirtualNetworkGatewayCreate(d *pluginsdk.ResourceData, meta interface{}) error {
@@ -975,12 +1001,11 @@ func resourceVirtualNetworkGatewayUpdate(d *pluginsdk.ResourceData, meta interfa
 		payload.Properties.AllowVirtualWanTraffic = pointer.To(d.Get("virtual_wan_traffic_enabled").(bool))
 	}
 
-	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") || d.HasChange("sku") {
-		payload.Properties.AutoScaleConfiguration = &virtualnetworkgateways.VirtualNetworkGatewayAutoScaleConfiguration{}
-		rawConfig := d.GetRawConfig().AsValueMap()
-		if !rawConfig["minimum_scale_unit"].IsNull() {
-			payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
-		}
+	// SKU changes that cross the availability-zone boundary are ForceNew (see
+	// resourceVirtualNetworkGatewayCustomizeDiff), so here we only need to push
+	// autoscale changes while the gateway stays on the ErGwScale SKU.
+	if d.HasChanges("minimum_scale_unit", "maximum_scale_unit") {
+		payload.Properties.AutoScaleConfiguration = expandVirtualNetworkGatewayAutoScaleConfiguration(d)
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
Hi @jiaweitao001 — this PR targets your `add_support_for_autoscale_config` branch to fix the failing `TestAccVirtualNetworkGateway_erGwScaleToStandard` test. Feel free to merge it in, adjust, or cherry-pick whatever is useful.

## Why
Changing an ExpressRoute gateway from `ErGwScale` to `Standard` in place isn't supported by the Azure API, so it can't be fixed by adjusting the `autoScaleConfiguration` payload. I reproduced the transition directly against the API (2025-01-01) and every payload variant fails server-side with the same error:

| Starting bounds | `autoScaleConfiguration` sent | Result |
|---|---|---|
| `min=1 / max=1` | `{}` (current branch) | ❌ `AutoscaleBoundsNotValid` |
| `min=1 / max=1` | omitted (`nil`) | ❌ same error |
| `min=2 / max=10` | omitted (`nil`) | ❌ same error |

```
ExpressRouteVirtualNetworkGatewayAutoscaleBoundsNotValid:
"ExpressRoute Virtual Network Gateway has invalid autoscale bounds.
 Min should be greater than 1 and less than Max 40."
```

The docs confirm it: `ErGwScale` is an availability-zone SKU and `Standard` is not, and in-place SKU changes are only allowed within the same family — [switching between AZ and non-AZ SKUs requires delete-and-recreate](https://learn.microsoft.com/azure/expressroute/expressroute-howto-add-gateway-portal-resource-manager#upgrade-a-gateway-sku). Full details are in my comment on #31628.

## What this changes
1. In `resourceVirtualNetworkGatewayCustomizeDiff`, mark `sku` as `ForceNew` when an ExpressRoute gateway's SKU change crosses the AZ boundary (`ErGw1AZ`/`ErGw2AZ`/`ErGw3AZ`/`ErGwScale` ⇄ `Standard`/`HighPerformance`/`UltraPerformance`).
2. Simplify the update path so it only pushes autoscale changes while the gateway stays on `ErGwScale` (the in-place case that does work). The empty-`{}` logic is removed.

With `ForceNew`, `erGwScaleToStandard` recreates the gateway as `Standard` instead of attempting the unsupported in-place change, so the existing test passes unchanged. I also confirmed a fresh `Standard` ExpressRoute gateway provisions with that test config (no public IP needed).

## Validation
- `gofmt` clean and `go build ./internal/services/network/` passes.
- Scoped to `gatewayType == ExpressRoute`, so VPN gateway behavior is untouched.

Thanks again for all the work on this feature.